### PR TITLE
bug inferring dtype for objects

### DIFF
--- a/src/synthesized_insight/check.py
+++ b/src/synthesized_insight/check.py
@@ -66,7 +66,7 @@ class ColumnCheck(Check):
 
         in_dtype = str(col.dtype)
         n_nans = col.isna().sum()
-        n_empty_str = (col.str.len() == 0).sum() if pd.api.types.is_string_dtype(col) else 0
+        n_empty_str = 0 if not pd.api.types.is_string_dtype(col) else (sr == "").sum()
 
         # Try to convert it to numeric
         if col.dtype.kind not in ("i", "u", "f") and col.dtype.kind != 'M':


### PR DESCRIPTION
For pandas 1.3.2, tests currently fail because objects are converted to floats automatically in pandas 1.1.5 (which we use for testing) when possible but not in 1.3.2. This causes sr.str to raise an error in 1.3.2, this is fixed by changing the sr.str call to an explicit sr == "" in the `infer_dtypes` function