### PR TITLE
Remove same domain method and expose OneColumnMetric

### DIFF
--- a/src/synthesized_insight/check.py
+++ b/src/synthesized_insight/check.py
@@ -72,11 +72,6 @@ class Check(ABC):
         """Checks if the given series is affine"""
         pass
 
-    @abstractmethod
-    def same_domain(self, sr_a: pd.Series, sr_b: pd.Series):
-        """Checks if the given columns have the same domain of values"""
-        pass
-
 
 class ColumnCheck(Check):
     """Utility to check the column or a pairs of columns for different conditions
@@ -143,15 +138,4 @@ class ColumnCheck(Check):
         if self.continuous(sr) is True\
            or self.infer_dtype(sr).dtype.kind in ("M", "m"):
             return True
-        return False
-
-    def same_domain(self, sr_a: pd.Series, sr_b: pd.Series) -> bool:
-        """Checks if the given columns have the same domain of values"""
-        sr_a = self.infer_dtype(sr_a)
-        sr_b = self.infer_dtype(sr_b)
-        if self.categorical(sr_a) is True and self.categorical(sr_b) is True\
-           and sr_a.dtype.kind != 'M' and sr_b.dtype.kind != 'M'\
-           and set(sr_a.dropna().unique()) == set(sr_b.dropna().unique()):
-            return True
-
         return False

--- a/src/synthesized_insight/metrics/__init__.py
+++ b/src/synthesized_insight/metrics/__init__.py
@@ -1,4 +1,4 @@
-from .base import TwoColumnMetric, TwoDataFrameMetric
+from .base import OneColumnMetric, TwoColumnMetric, TwoDataFrameMetric
 from .metrics import (
     CramersV,
     DistanceCNCorrelation,
@@ -35,7 +35,7 @@ from .statistical_tests import (
     SpearmanRhoCorrelationTest,
 )
 
-__all__ = ['TwoColumnMetric', 'CramersV', 'EarthMoversDistance', 'KendallTauCorrelationTest',
+__all__ = ['OneColumnMetric', 'TwoColumnMetric', 'CramersV', 'EarthMoversDistance', 'KendallTauCorrelationTest',
            'KolmogorovSmirnovDistanceTest', 'Mean', 'SpearmanRhoCorrelationTest', 'StandardDeviation',
            'ROCAUC', 'Accuracy', 'ConfusionMatrix', 'F1Score', 'MeanAbsoluteError', 'KruskalWallisTest',
            'MeanSquaredError', 'PRCurve', 'Precision', 'R2Score', 'Recall', 'ROCCurve', 'Norm',

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -66,24 +66,6 @@ def test_column_check(df):
     verify_columns_types(df_nan, categorical_cols, continuous_cols, affine_cols, ordinal_cols)
 
 
-def test_same_domain_columns(df):
-    check = ColumnCheck()
-
-    string_col_copy = pd.Series(np.random.permutation(copy.deepcopy(df['string_col'])))
-    assert check.same_domain(df['string_col'], string_col_copy) is True
-
-    string_col_copy = string_col_copy.append(pd.Series([None]))
-    assert check.same_domain(df['string_col'], string_col_copy) is True
-
-    string_col_copy = string_col_copy.append(pd.Series(['P']))
-    assert check.same_domain(df['string_col'], string_col_copy) is False
-
-    date_col_copy = pd.Series(np.random.permutation(copy.deepcopy(df['date_col'])))
-    assert check.same_domain(df['date_col'], date_col_copy) is False
-
-    assert check.same_domain(df['date_col'], df['string_col']) is False
-
-
 def test_check_ordinal():
     check = ColumnCheck()
 


### PR DESCRIPTION
Removed same_domain method from Check class, needed for SDKCheck class
Added OneColumnMetric to __init__.py
