### PR TITLE
EarthMoverDistanceBinned should be able to take bins

### DIFF
--- a/src/synthesized_insight/metrics/metrics.py
+++ b/src/synthesized_insight/metrics/metrics.py
@@ -436,7 +436,7 @@ class EarthMoversDistanceBinned(TwoColumnMetric):
     an ordinal range. If the latter, they must have equal binning.
 
     Args:
-        bins: Optional; If given, this must be an iterable of bin edges for x and y,
+        bin_edges: Optional; If given, this must be an iterable of bin edges for x and y,
                 i.e the output of np.histogram_bin_edges. If None, then it is assumed
                 that the data represent counts of nominal categories, with no meaningful
                 distance between bins.

--- a/src/synthesized_insight/metrics/metrics.py
+++ b/src/synthesized_insight/metrics/metrics.py
@@ -452,11 +452,8 @@ class EarthMoversDistanceBinned(TwoColumnMetric):
 
     @classmethod
     def check_column_types(cls, sr_a: pd.Series, sr_b: pd.Series, check: Check = ColumnCheck()) -> bool:
-        if check.continuous(sr_a) and check.continuous(sr_b):
-            return True
-        if check.categorical(sr_a) and check.categorical(sr_b):
-            return True
-        return False
+        # Histograms can appear to be continuous even if they are categorical in nature
+        return True
 
     def _compute_metric(self, sr_a: pd.Series, sr_b: pd.Series):
         """
@@ -487,7 +484,6 @@ class EarthMoversDistanceBinned(TwoColumnMetric):
             # otherwise, use pair-wise euclidean distances between bin centers for scale data
             bin_centers = self.bin_edges[:-1] + np.diff(self.bin_edges) / 2.
             distance = wasserstein_distance(bin_centers, bin_centers, u_weights=x, v_weights=y)
-
         return distance
 
 

--- a/src/synthesized_insight/metrics/metrics.py
+++ b/src/synthesized_insight/metrics/metrics.py
@@ -471,11 +471,11 @@ class EarthMoversDistanceBinned(TwoColumnMetric):
         bin_edges = self.bin_edges
         if bin_edges is None:
             if self.check.categorical(sr_a):
-                raise ValueError("For histograms, bins edges should be provided. If categorical,\
-                then use EarthMoversDistance")
-
-            (p, q), bin_edges = zipped_hist((sr_a, sr_b), check=self.check, ret_bins=True)
-            assert bin_edges is not None, "bin edges should return not None if inputs are continuous"
+                emd = EarthMoversDistance(check=self.check)
+                return emd(sr_a, sr_b)
+            else:
+                (p, q), bin_edges = zipped_hist((sr_a, sr_b), check=self.check, ret_bins=True)
+                assert bin_edges is not None, "bin edges should return not None if inputs are continuous"
         else:
             p, q = sr_a, sr_b
 

--- a/src/synthesized_insight/metrics/statistical_tests.py
+++ b/src/synthesized_insight/metrics/statistical_tests.py
@@ -19,7 +19,7 @@ class BinomialDistanceTest(TwoColumnTest):
 
     @classmethod
     def check_column_types(cls, sr_a: pd.Series, sr_b: pd.Series, check: Check = ColumnCheck()) -> bool:
-        return pd.concat((sr_a, sr_b)).nunique() == 2
+        return (pd.concat((sr_a, sr_b)).nunique() == 2)
 
     def _compute_test(self, sr_a: pd.Series, sr_b: pd.Series) -> Tuple[Union[int, float, None], Union[int, float, None]]:
         """Calculate binomial metric and exact p-value for an observed binomial proportion of a sample."""

--- a/src/synthesized_insight/metrics/statistical_tests.py
+++ b/src/synthesized_insight/metrics/statistical_tests.py
@@ -19,7 +19,7 @@ class BinomialDistanceTest(TwoColumnTest):
 
     @classmethod
     def check_column_types(cls, sr_a: pd.Series, sr_b: pd.Series, check: Check = ColumnCheck()) -> bool:
-        return (pd.concat((sr_a, sr_b)).nunique() == 2)
+        return sr_a.append(sr_b).nunique() == 2
 
     def _compute_test(self, sr_a: pd.Series, sr_b: pd.Series) -> Tuple[Union[int, float, None], Union[int, float, None]]:
         """Calculate binomial metric and exact p-value for an observed binomial proportion of a sample."""

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -237,3 +237,5 @@ def test_emd_distance_binned():
     x, _ = np.histogram(a, bins=bin_edges)
     y, _ = np.histogram(b, bins=bin_edges)
     compare_and_log(pd.Series(x), pd.Series(y), bin_edges, 4.0)
+    compare_and_log(pd.Series([0, 3, 6, 14, 3]), pd.Series([1, 0, 8, 21, 1]), None, 0.20)
+    compare_and_log(pd.Series([0, 3, 6, 14, 3]), pd.Series([0, 3, 6, 14, 3]), None, 0.0)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -239,3 +239,5 @@ def test_emd_distance_binned():
     compare_and_log(pd.Series(x), pd.Series(y), bin_edges, 4.0)
     compare_and_log(pd.Series([0, 3, 6, 14, 3]), pd.Series([1, 0, 8, 21, 1]), None, 0.20)
     compare_and_log(pd.Series([0, 3, 6, 14, 3]), pd.Series([0, 3, 6, 14, 3]), None, 0.0)
+    compare_and_log(pd.Series([0, 0, 0, 0]), pd.Series([0, 3, 6, 14]), None, 1.0)
+    compare_and_log(pd.Series([0, 0, 0, 0]), pd.Series([0, 0, 0, 0]), None, 0.0)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -222,9 +222,18 @@ def test_r2_mcfadden_correlation():
 
 
 def test_emd_distance_binned():
+
+    def compare_and_log(x, y, bin_edges, val):
+        emdb = EarthMoversDistanceBinned(bin_edges=bin_edges)
+        metric_val = emdb(x, y)
+        assert np.isclose(metric_val, val, rtol=0.1)
+
+    compare_and_log(pd.Series([1, 2, 3]), pd.Series([1, 0, 3]), bin_edges=[0, 1, 2, 3], val=0.333)
+
     a = pd.Series(np.random.normal(loc=10, scale=1.0, size=10000))
     b = pd.Series(np.random.normal(loc=14, scale=1.0, size=10000))
 
-    emdb = EarthMoversDistanceBinned()
-    metric_val = emdb(a, b)
-    assert np.isclose(metric_val, 4, rtol=0.1)
+    bin_edges = np.histogram_bin_edges(np.concatenate((a, b), axis=0), bins=100)
+    x, _ = np.histogram(a, bins=bin_edges)
+    y, _ = np.histogram(b, bins=bin_edges)
+    compare_and_log(pd.Series(x), pd.Series(y), bin_edges, 4.0)


### PR DESCRIPTION
Presently, EarthMoverDistanceBinned (modeled from fairlens) doesn't handle input bins. Used the SDK's version of the EarthMoverDistanceBinned to handle all cases. Also, since the histograms provided as input in the EarthMoverDistanceBinned can be both categorical and continuous in appearance hence removed the column check because there doesn't appear to be a way to generalize it for both the columns.
SDK's linkage_attack module needs EarthMoverDistanceBinned which takes the bins