### PR TITLE
Use correct metric name

### DIFF
--- a/src/insight/metrics/metrics_usage.py
+++ b/src/insight/metrics/metrics_usage.py
@@ -128,7 +128,7 @@ class TwoColumnMap(TwoDataFrameMetric):
             for col in df_old.columns
         }
         result = pd.DataFrame(
-            data=columns_map.values(), index=df_old.columns, columns=["metric_val"]
+            data=columns_map.values(), index=df_old.columns, columns=[self.name]
         )
 
         result.name = self._metric.name


### PR DESCRIPTION
`TwoColumnMap` creates a DataFrame with column name "metric_val". This PR updates the column name to reflect the metric that is actually being calculated