### PR TITLE
Fix install failure on mac arm 64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ dependencies = [
   db = [
     "alembic",
     "sqlalchemy >= 2.0",
-    "psycopg2 >= 2.9",
+    "psycopg2 >= 2.9; platform_machine!='arm64' or platform_system!='Darwin'",
+    "psycopg2-binary >= 2.9; platform_machine=='arm64' or platform_system=='Darwin'",
   ]
 
   test = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,8 @@ numpy==1.21.6
 packaging==23.1
 pandas==1.3.5
 Pillow==10.0.0
-psycopg2==2.9.2
+psycopg2==2.9.2; platform_machine!='arm64' or platform_system!='Darwin'
+psycopg2-binary==2.9.2; platform_machine=='arm64' or platform_system=='Darwin'
 pyparsing==3.1.1
 python-dateutil==2.8.2
 pytz==2023.3.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ packaging==23.1
 pandas==1.3.5
 Pillow==10.0.0
 psycopg2==2.9.2; platform_machine!='arm64' or platform_system!='Darwin'
-psycopg2-binary==2.9.2; platform_machine=='arm64' or platform_system=='Darwin'
+psycopg2-binary==2.9.9; platform_machine=='arm64' or platform_system=='Darwin'
 pyparsing==3.1.1
 python-dateutil==2.8.2
 pytz==2023.3.post1


### PR DESCRIPTION
Install using pyproject.toml and requirements.txt was failing on mac arm64 with the following error:

```
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [23 lines of output]
      running egg_info
      creating /private/var/folders/6v/8t3yrz1906547q16rrbtzw3c0000gn/T/pip-pip-egg-info-i0xhy0sj/psycopg2_binary.egg-info
      writing /private/var/folders/6v/8t3yrz1906547q16rrbtzw3c0000gn/T/pip-pip-egg-info-i0xhy0sj/psycopg2_binary.egg-info/PKG-INFO
      writing dependency_links to /private/var/folders/6v/8t3yrz1906547q16rrbtzw3c0000gn/T/pip-pip-egg-info-i0xhy0sj/psycopg2_binary.egg-info/dependency_links.txt
      writing top-level names to /private/var/folders/6v/8t3yrz1906547q16rrbtzw3c0000gn/T/pip-pip-egg-info-i0xhy0sj/psycopg2_binary.egg-info/top_level.txt
      writing manifest file '/private/var/folders/6v/8t3yrz1906547q16rrbtzw3c0000gn/T/pip-pip-egg-info-i0xhy0sj/psycopg2_binary.egg-info/SOURCES.txt'
      
      Error: pg_config executable not found.
      
      pg_config is required to build psycopg2 from source.  Please add the directory
      containing pg_config to the $PATH or specify the full executable path with the
      option:
      
          python setup.py build_ext --pg-config /path/to/pg_config build ...
      
      or with the pg_config option in 'setup.cfg'.
      
      If you prefer to avoid building psycopg2 from source, please install the PyPI
      'psycopg2-binary' package instead.
      
      For further information please check the 'doc/src/install.rst' file (also at
      <https://www.psycopg.org/docs/install.html>).
      
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

```


the fix is to use psycopg2-binary if on mac arm64