### PR TITLE
pin requirements for CI testing

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -30,7 +30,7 @@ jobs:
           path: .tenv
           key: pip-tenv-${{ steps.setup-py.outputs.python-version }}-${{ hashFiles('requirements.txt') }}
           restore-keys: |
-            pip-tenv-${{ steps.setup-py.outputs.python-version }}-*
+            pip-tenv-${{ steps.setup-py.outputs.python-version }}-
 
       - name: Create test-venv
         if: steps.python_cache.outputs.cache-hit != 'true'

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -24,13 +24,19 @@ jobs:
         with:
           python-version: 3.7
 
-      - name: Cache test venv
+      - id: python_cache
         uses: actions/cache@v3
         with:
-          path: .pip-cache
-          key: ${{ runner.os }}-pip-tenv-${{ steps.setup-py.outputs.python-version }}-${{ hashFiles('./pyproject.toml') }}
+          path: .tenv
+          key: pip-tenv-${{ steps.setup-py.outputs.python-version }}-${{ hashFiles('requirements.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-tenv-${{ steps.setup-py.outputs.python-version }}
+            pip-tenv-${{ steps.setup-py.outputs.python-version }}
+
+      - name: Create test-venv
+        if: steps.python_cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          python -m venv .tenv
 
       - name: Create test-venv
         run: |
@@ -42,7 +48,7 @@ jobs:
         run: |
           source .tenv/bin/activate
           python -m build --wheel
-          pip install $(ls dist/*.whl)[db,test] --cache-dir .pip-cache
+          pip install $(ls dist/*.whl)[db,test] -c requirements.txt --cache-dir .pip-cache 
 
       - name: Run unit tests
         run: |

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -14,7 +14,7 @@ jobs:
     continue-on-error: true
 
     steps:
-      - uses: actions/checkout@v3.0.2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -22,10 +22,10 @@ jobs:
         id: setup-py
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - id: python_cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .tenv
           key: pip-tenv-${{ steps.setup-py.outputs.python-version }}-${{ hashFiles('requirements.txt') }}
@@ -55,13 +55,13 @@ jobs:
           source .tenv/bin/activate
           pytest -v --junitxml=test-results/junit.xml  --cov=insight --cov-report=xml:coverage-reports/cobertura.xml --cov-branch --log-cli-level=INFO
           sed -ie 's#/home/runner/work/insight/insight#/github/workspace/src#g' coverage-reports/cobertura.xml
-          sed -ie 's#.tenv/lib/python3.7/site-packages/##g' coverage-reports/cobertura.xml
-          sed -ie 's#.tenv.lib.python3.7.site-packages.##g' coverage-reports/cobertura.xml
+          sed -ie 's#.tenv/lib/python3.8/site-packages/##g' coverage-reports/cobertura.xml
+          sed -ie 's#.tenv.lib.python3.8.site-packages.##g' coverage-reports/cobertura.xml
         env:
           SYNTHESIZED_KEY: ${{ secrets.SYNTHESIZED_KEY }}
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: coverage-reports/cobertura.xml

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,7 +22,7 @@ jobs:
         id: setup-py
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.8.18
 
       - id: python_cache
         uses: actions/cache@v4
@@ -30,7 +30,7 @@ jobs:
           path: .tenv
           key: pip-tenv-${{ steps.setup-py.outputs.python-version }}-${{ hashFiles('requirements.txt') }}
           restore-keys: |
-            pip-tenv-${{ steps.setup-py.outputs.python-version }}
+            pip-tenv-${{ steps.setup-py.outputs.python-version }}-*
 
       - name: Create test-venv
         if: steps.python_cache.outputs.cache-hit != 'true'

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -48,7 +48,7 @@ jobs:
         run: |
           source .tenv/bin/activate
           python -m build --wheel
-          pip install $(ls dist/*.whl)[db,test] -c requirements.txt --cache-dir .pip-cache 
+          pip install $(ls dist/*.whl)[db,test] -c requirements.txt --cache-dir .pip-cache
 
       - name: Run unit tests
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,31 +1,10 @@
 alembic==1.7.6
 cachetools==5.3.1
-contourpy==1.1.0
-cycler==0.11.0
-fonttools==4.42.1
-greenlet==2.0.2
-importlib-resources==6.0.1
-kiwisolver==1.4.5
-Mako==1.2.4
-MarkupSafe==2.1.3
 matplotlib==3.7.3
-mypy==1.5.1
-mypy-extensions==1.0.0
 numpy==1.21.6
-packaging==23.1
 pandas==1.3.5
-Pillow==10.0.0
 psycopg2==2.9.2; platform_machine!='arm64' or platform_system!='Darwin'
 psycopg2-binary==2.9.9; platform_machine=='arm64' or platform_system=='Darwin'
-pyparsing==3.1.1
-python-dateutil==2.8.2
-pytz==2023.3.post1
 scipy==1.10.1
 seaborn==0.12.2
-six==1.16.0
 SQLAlchemy==1.4.40
-sqlalchemy2-stubs==0.0.2a35
-synthesized-datasets==1.0
-tomli==2.0.1
-typing_extensions==4.7.1
-zipp==3.16.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-alembic==1.13.2
+alembic==1.13.1
 cachetools==5.3.1
 matplotlib==3.7.3
 numpy==1.21.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ psycopg2==2.9.2; platform_machine!='arm64' or platform_system!='Darwin'
 psycopg2-binary==2.9.9; platform_machine=='arm64' or platform_system=='Darwin'
 scipy==1.10.1
 seaborn==0.12.2
-SQLAlchemy==1.4.40
+SQLAlchemy==2.0.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-alembic==1.7.6
+alembic==1.13.2
 cachetools==5.3.1
 matplotlib==3.7.3
 numpy==1.21.6


### PR DESCRIPTION
Pinning the requirements to requirements.txt will keep the CI more stable and reliable.