### PR TITLE
Drop NaN in KolmogorovSmirnov

### DIFF
--- a/src/insight/metrics/metrics.py
+++ b/src/insight/metrics/metrics.py
@@ -534,4 +534,4 @@ class KolmogorovSmirnovDistance(TwoColumnMetric):
         """
         if sr_a.empty or sr_b.empty:
             return 1.0
-        return ks_2samp(sr_a, sr_b)[0]  # The first element is the KS statistic
+        return ks_2samp(sr_a, sr_b, nan_policy="omit")[0]  # The first element is the KS statistic

--- a/src/insight/metrics/metrics.py
+++ b/src/insight/metrics/metrics.py
@@ -534,4 +534,5 @@ class KolmogorovSmirnovDistance(TwoColumnMetric):
         """
         if sr_a.empty or sr_b.empty:
             return 1.0
-        return ks_2samp(sr_a, sr_b, nan_policy="omit")[0]  # The first element is the KS statistic
+
+        return ks_2samp(sr_a.dropna(), sr_b.dropna())[0]  # The first element is the KS statistic


### PR DESCRIPTION
With the current setup, where there was 1 or more NaN values in either of the `pd.Series` used in the KS calculation NaN was returned. This is not the desired behaviour, instead we want NaN values to be ignored. 

This PR adjusts the metric to ensure that NaN values are dropped from each series before calculation.